### PR TITLE
Add keyboard RGB controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,21 @@ Visualiza un arcoíris animado en la terminal sincronizado con el audio
 capturado por el micrófono.
 
 ## `keyboard_rgb.py`
-Activa la iluminación RGB de un teclado compatible mediante
-[OpenRGB](https://openrgb.org/). El script detecta un teclado HID en
-Windows usando `pywinusb` y cambia su color en un ciclo de arcoíris.
+Controla las luces de un teclado a través de
+[OpenRGB](https://openrgb.org/). El script se conecta a un servidor
+OpenRGB local o remoto y recorre los colores del arcoíris.
+
+OpenRGB no tiene soporte nativo para macOS, por lo que puedes
+ejecutarlo en otra máquina (Windows o Linux) o en una máquina virtual y
+usar la opción `--host` para indicar su dirección.
 
 ### Requisitos
 - Python 3
-- `pip install openrgb-python pywinusb`
-- Ejecutar OpenRGB con `--server` antes de lanzar el script.
+- `pip install openrgb-python`
+- Un servidor OpenRGB ejecutándose con la opción `--server`.
 
 ### Uso
 ```bash
-python keyboard_rgb.py
+python keyboard_rgb.py --show --host 127.0.0.1
 ```
 Interrumpe con `Ctrl+C` para apagar las luces.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Rainvow Tools
+
+Este repositorio contiene utilidades de Python para efectos visuales.
+
+## `ondads.py`
+Visualiza un arcoíris animado en la terminal sincronizado con el audio
+capturado por el micrófono.
+
+## `keyboard_rgb.py`
+Activa la iluminación RGB de un teclado compatible mediante
+[OpenRGB](https://openrgb.org/). El script detecta un teclado HID en
+Windows usando `pywinusb` y cambia su color en un ciclo de arcoíris.
+
+### Requisitos
+- Python 3
+- `pip install openrgb-python pywinusb`
+- Ejecutar OpenRGB con `--server` antes de lanzar el script.
+
+### Uso
+```bash
+python keyboard_rgb.py
+```
+Interrumpe con `Ctrl+C` para apagar las luces.

--- a/keyboard_rgb.py
+++ b/keyboard_rgb.py
@@ -1,0 +1,62 @@
+"""Keyboard RGB control using OpenRGB.
+
+Este script detecta un teclado HID en Windows y controla sus
+luces RGB a través de OpenRGB. Asegúrate de tener OpenRGB
+corriendo con la opción --server y de haber instalado las
+librerías openrgb-python y pywinusb.
+"""
+
+import time
+import colorsys
+
+from openrgb import OpenRGBClient
+from openrgb.utils import RGBColor
+import pywinusb.hid as hid
+
+
+def find_keyboard():
+    """Devuelve (vendor_id, product_id) del primer teclado HID."""
+    for device in hid.HidDeviceFilter().get_devices():
+        try:
+            caps = device.hid_caps
+            if caps.usage_page == 0x01 and caps.usage == 0x06:
+                return device.vendor_id, device.product_id
+        except AttributeError:
+            continue
+    return None, None
+
+
+def rainbow_cycle(device, steps=360, delay=0.05):
+    for i in range(steps):
+        hue = i / float(steps)
+        r, g, b = [int(255 * x) for x in colorsys.hsv_to_rgb(hue, 1, 1)]
+        device.set_color(RGBColor(r, g, b))
+        time.sleep(delay)
+
+
+def main():
+    vid, pid = find_keyboard()
+    if vid is None:
+        print("No se encontró un teclado HID.")
+    else:
+        print(f"Teclado detectado: VID={vid:04X}, PID={pid:04X}")
+
+    client = OpenRGBClient()
+    keyboards = [d for d in client.devices if d.device_type.name == "KEYBOARD"]
+    if not keyboards:
+        print("No hay teclados compatibles en OpenRGB.")
+        return
+
+    keyboard = keyboards[0]
+    print(f"Controlando {keyboard.name} con OpenRGB")
+
+    try:
+        while True:
+            rainbow_cycle(keyboard)
+    except KeyboardInterrupt:
+        keyboard.set_color(RGBColor(0, 0, 0))
+        print("\nTerminando")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- show how to run the audio rainbow display
- add a Windows example for controlling keyboard RGB via OpenRGB

## Testing
- `python -m py_compile ondads.py keyboard_rgb.py`

------
https://chatgpt.com/codex/tasks/task_e_68585d114380832881b8f0e1376c8c42