### PR TITLE
Add AuraWave p5.js visualizer

### DIFF
--- a/aurawave/index.html
+++ b/aurawave/index.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+<title>AuraWave</title>
+<style>
+html, body {
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  background: #000;
+}
+canvas { display: block; }
+</style>
+</head>
+<body>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.6.0/p5.min.js"></script>
+<script>
+let mic, amp;
+let startTime = 0;
+const presetDuration = 20000; // 20 seconds
+let presetIndex = 0;
+const presets = [];
+
+function setup() {
+  createCanvas(windowWidth, windowHeight);
+  colorMode(HSB, 360, 100, 100, 100);
+  mic = new p5.AudioIn();
+  amp = new p5.Amplitude();
+  amp.setInput(mic);
+  // Need user interaction to start audio
+  textAlign(CENTER, CENTER);
+  textSize(24);
+  fill(255);
+  startTime = millis();
+  presets.push(borderWave);
+  presets.push(curvedHalo);
+  presets.push(kaleidoPulse);
+}
+
+function mousePressed() {
+  userStartAudio();
+  mic.start();
+}
+
+function windowResized() {
+  resizeCanvas(windowWidth, windowHeight);
+}
+
+function draw() {
+  background(0);
+  let level = amp.getLevel();
+  if (millis() - startTime > presetDuration) {
+    startTime = millis();
+    presetIndex = (presetIndex + 1) % presets.length;
+  }
+  presets[presetIndex](level);
+  if (!mic.enabled) {
+    fill(255);
+    text('Click to start', width/2, height/2);
+  }
+}
+
+function borderWave(level) {
+  strokeWeight(4);
+  const hue = (frameCount % 360);
+  stroke(hue, 80, 100);
+  const offset = map(level, 0, 1, 0, 20);
+  // top
+  line(offset, offset, width - offset, offset);
+  // right
+  line(width - offset, offset, width - offset, height - offset);
+  // bottom
+  line(width - offset, height - offset, offset, height - offset);
+  // left
+  line(offset, height - offset, offset, offset);
+}
+
+function curvedHalo(level) {
+  strokeWeight(3);
+  const radius = map(level, 0, 1, width * 0.3, width * 0.45);
+  stroke((frameCount * 2) % 360, 80, 100);
+  noFill();
+  ellipse(width/2, height/2, radius*2);
+}
+
+function kaleidoPulse(level) {
+  push();
+  translate(width/2, height/2);
+  const r = map(level, 0, 1, width*0.2, width*0.4);
+  const angleStep = PI/3;
+  stroke((frameCount * 3) % 360, 80, 100);
+  strokeWeight(3);
+  for (let i = 0; i < 6; i++) {
+    const x = r * cos(angleStep * i + frameCount * 0.02);
+    const y = r * sin(angleStep * i + frameCount * 0.02);
+    line(0,0,x,y);
+  }
+  pop();
+}
+
+/* Firebase integration placeholder
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.6.8/firebase-app.js';
+const firebaseConfig = {
+  // your config here
+};
+const app = initializeApp(firebaseConfig);
+// Use Firebase to load custom presets in the future
+*/
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `aurawave/index.html` with p5.js visualizer using microphone input
- implement border wave, curved halo and kaleido pulse presets
- include placeholder code for future Firebase integration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861f972a2908328a4e9636d323752de