### PR TITLE
Add screenshot utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# Rainvow AR Demo
+
+Este proyecto incluye una sencilla demostración de realidad aumentada con [A-Frame](https://aframe.io/) y [AR.js](https://ar-js-org.github.io/AR.js/). El archivo `ar.html` despliega un cubo 3D animado cuando la cámara detecta el marcador *hiro*.
+Para hacerlo más visual, se integra [Hydra-synth](https://github.com/ojack/hydra) como capa de efectos sobre la escena.
+
+## Cómo ejecutar
+
+1. Inicia un servidor local en la raíz del proyecto. Por ejemplo:
+   
+   ```bash
+   # Con Python
+   python3 -m http.server
+   
+   # o con Node
+   npx http-server
+   ```
+2. Abre `http://localhost:8000/ar.html` en un navegador moderno (Chrome, Firefox, Safari).
+3. Concede permisos de cámara cuando lo solicite el navegador.
+4. Apunta la cámara a un marcador *hiro*. Puedes imprimir uno desde [este enlace](https://raw.githubusercontent.com/AR-js-org/AR.js/master/data/images/HIRO.jpg).
+
+Para que la cámara funcione, la página debe servirse mediante `https` o desde `localhost`.
+
+## Requisitos
+
+- Navegador con soporte WebGL y permisos de cámara.
+- Conexión segura (HTTPS o entorno local) para acceder a la cámara.
+
+Esta demo es autónoma y no necesita dependencias adicionales.
+
+### Efecto Hydra
+
+Al abrir `ar.html`, notarás una capa de patrones generativos. Estos efectos se generan con Hydra-synth y se mezclan sobre la imagen de la cámara para dar un aspecto más dinámico. Puedes modificar el código de Hydra en el archivo para experimentar con otros visuales.
+
+### Lectura de PDFs con Hydra
+
+También puedes abrir `pdf_overlay.html` para cargar un archivo PDF desde tu equipo. La página renderiza la primera página del documento y superpone una capa de efectos con Hydra-synth, ideal para resaltar pasos importantes o experimentar con anotaciones visuales.
+
+1. Inicia el servidor como en el paso anterior.
+2. Abre `http://localhost:8000/pdf_overlay.html`.
+3. Selecciona un PDF local desde el control "Cargar PDF".
+
+El efecto Hydra se puede modificar editando el código de la página para ajustar colores y animaciones.
+
+### Capturas de pantalla
+
+Si deseas guardar una imagen de tu escritorio para documentar tus experimentos, utiliza el script `screenshot.py`:
+
+```bash
+pip install pyautogui colorama
+python3 screenshot.py --tag prueba
+```
+
+Las capturas se guardarán en la carpeta `screenshots` y el mensaje aparecerá resaltado en azul para mayor claridad.

--- a/ar.html
+++ b/ar.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AR Demo</title>
+  <script src="https://aframe.io/releases/1.4.0/aframe.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/AR-js-org/AR.js@3.3.2/aframe/build/aframe-ar.js"></script>
+  <script src="https://unpkg.com/hydra-synth"></script>
+  <style>
+    body, html {
+      margin: 0;
+      padding: 0;
+      overflow: hidden;
+    }
+    #info {
+      position: absolute;
+      top: 10px;
+      left: 50%;
+      transform: translateX(-50%);
+      color: white;
+      background: rgba(0, 0, 0, 0.5);
+      padding: 8px 12px;
+      border-radius: 4px;
+      font-family: sans-serif;
+      z-index: 1;
+    }
+    #hydra-canvas {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+      mix-blend-mode: screen;
+      opacity: 0.5;
+      z-index: 0;
+    }
+  </style>
+</head>
+<body>
+  <canvas id="hydra-canvas"></canvas>
+  <div id="info">Apunta al marcador "hiro" para ver el cubo</div>
+  <a-scene embedded arjs="sourceType: webcam; debugUIEnabled: false;">
+    <a-marker preset="hiro">
+      <a-box position="0 0.5 0" material="color: #4CC3D9;" 
+             animation="property: rotation; to: 0 360 0; loop: true; dur: 3000"></a-box>
+    </a-marker>
+    <a-entity camera></a-entity>
+  </a-scene>
+
+  <script>
+    const hydra = new Hydra({ canvas: document.getElementById('hydra-canvas'), detectAudio: false });
+    osc(10, 0.1, 1.2)
+      .color(0.8, 0.3, 1.0)
+      .rotate(0, 0.1)
+      .kaleid(3)
+      .out();
+  </script>
+</body>
+</html>

--- a/pdf_overlay.html
+++ b/pdf_overlay.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PDF Overlay Demo</title>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
+  <script src="https://unpkg.com/hydra-synth"></script>
+  <style>
+    html, body { margin: 0; height: 100%; font-family: sans-serif; }
+    #controls { padding: 6px; background: #222; color: #fff; }
+    #pdf-canvas { width: 100%; height: calc(100% - 40px); }
+    #hydra-canvas { position: absolute; top: 0; left: 0; width: 100%; height: calc(100% - 40px); pointer-events: none; mix-blend-mode: screen; opacity: 0.5; }
+  </style>
+</head>
+<body>
+  <div id="controls">
+    <label>Cargar PDF: <input type="file" id="file-input" accept="application/pdf"></label>
+  </div>
+  <canvas id="pdf-canvas"></canvas>
+  <canvas id="hydra-canvas"></canvas>
+  <script>
+    const pdfjsLib = window['pdfjs-dist/build/pdf'];
+    pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js';
+    const canvas = document.getElementById('pdf-canvas');
+    const context = canvas.getContext('2d');
+
+    function renderPDF(arrayBuffer) {
+      pdfjsLib.getDocument({ data: arrayBuffer }).promise.then(pdf => {
+        pdf.getPage(1).then(page => {
+          const viewport = page.getViewport({ scale: 1.5 });
+          canvas.width = viewport.width;
+          canvas.height = viewport.height;
+          page.render({ canvasContext: context, viewport });
+        });
+      });
+    }
+
+    document.getElementById('file-input').addEventListener('change', e => {
+      const file = e.target.files[0];
+      if (!file) return;
+      file.arrayBuffer().then(renderPDF);
+    });
+
+    // Hydra overlay
+    const hydra = new Hydra({ canvas: document.getElementById('hydra-canvas'), detectAudio: false });
+    osc(4, 0.1, 0.8)
+      .color(0.6, 0.3, 1.0)
+      .rotate(0, 0.05)
+      .out();
+  </script>
+</body>
+</html>

--- a/screenshot.py
+++ b/screenshot.py
@@ -1,0 +1,22 @@
+import os
+import time
+import pyautogui
+from colorama import Fore, Style
+
+LOG_DIR = os.path.join(os.path.dirname(__file__), 'screenshots')
+os.makedirs(LOG_DIR, exist_ok=True)
+
+def color(text, hue):
+    return f"{hue}{text}{Style.RESET_ALL}"
+
+def take_screenshot(tag="default"):
+    filename = os.path.join(LOG_DIR, f"snap_{tag}_{int(time.time())}.png")
+    pyautogui.screenshot(filename)
+    print(color(f"[Hydra] Screenshot saved: {filename}", Fore.BLUE))
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Capture a screenshot with colorful logging")
+    parser.add_argument('--tag', default='default', help='Tag for the output filename')
+    args = parser.parse_args()
+    take_screenshot(args.tag)


### PR DESCRIPTION
## Summary
- add a small `screenshot.py` helper that saves desktop captures
- document screenshot usage in the README

## Testing
- `pytest -q`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6872f3b497a483288661da90a1e0f136